### PR TITLE
Fix text overflow in header

### DIFF
--- a/assets/css/grid.css
+++ b/assets/css/grid.css
@@ -203,3 +203,9 @@ header .emoji .ltr {
         display: none;
   }
 }
+
+@media screen and (max-width: 350px) {
+  header .logo .emoji {
+        display: none;
+  }
+}


### PR DESCRIPTION
На маленьких экранах мобильных (например, iPhone 5/5s/SE, width=320) текст хедера переносится и налазит на контент.
![image](https://user-images.githubusercontent.com/5827605/62965640-2751c280-be0e-11e9-8018-e1951683aa5f.png)

Можно было, конечно, другими способами решить эту проблему, но самый простой, по моему, скрыть emoji на маленьких экранах.
Результат:
![underjs ru_podcast_2019_08_12_kak-dolzhen-vyglyadit-nastoyashchy-backend html(iPhone 5_SE) (2)](https://user-images.githubusercontent.com/5827605/62965757-5a945180-be0e-11e9-8a85-0672023d5b12.png)


